### PR TITLE
Use valid version in library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=TaskScheduler
-version=1.01
+version=1.1
 author=José Ángel Jiménez Vadillo <jose.angel.jimenez@gmail.com>
 maintainer=José Ángel Jiménez Vadillo <jose.angel.jimenez@gmail.com>
 sentence=Simple scheduler library for AVR ATmega MCUs and Arduino.


### PR DESCRIPTION
The previous `version` value caused the Arduino IDE to display warnings:
```
Invalid version found: 1.01
```
This warning can be especially confusing for users since the Arduino IDE doesn't say which library is the source of the problem.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#libraryproperties-file-format